### PR TITLE
Action input messages. Fixes JB#55555

### DIFF
--- a/src/notification.h
+++ b/src/notification.h
@@ -182,10 +182,12 @@ public:
     Q_INVOKABLE static QVariant remoteAction(const QString &name, const QString &displayName,
                                              const QString &service = QString(), const QString &path = QString(), const QString &iface = QString(),
                                              const QString &method = QString(), const QVariantList &arguments = QVariantList());
+    static QVariant actionSetInputFormat(QVariant &action, QString &label, bool editable, const QStringList &choices = QStringList());
 
 signals:
     void clicked();
     void actionInvoked(const QString &name);
+    void inputActionInvoked(const QString &name, const QString &inputText);
     void closed(uint reason);
     void categoryChanged();
     void appNameChanged();
@@ -213,6 +215,7 @@ signals:
 private slots:
     void checkActionInvoked(uint id, QString actionKey);
     void checkNotificationClosed(uint id, uint reason);
+    void checkInputTextSet(uint id, const QString &inputText);
 
 private:
     NotificationPrivate * const d_ptr;

--- a/src/notification_p.h
+++ b/src/notification_p.h
@@ -54,6 +54,7 @@ struct NotificationData
     QList<ActionInfo> actions;
     QVariantHash hints;
     qint32 expireTimeout = -1;
+    QString inputText;
 };
 
 class NotificationManagerProxy;

--- a/src/org.freedesktop.Notifications.xml
+++ b/src/org.freedesktop.Notifications.xml
@@ -46,5 +46,9 @@
       <arg name="notifications" type="a(sussasa{sv}i)" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QList &lt; NotificationData &gt; "/>
     </method>
+    <signal name="InputTextSet">
+      <arg name="id" type="u"/>
+      <arg name="input" type="s"/>
+    </signal>
   </interface>
 </node>

--- a/src/plugin/plugins.qmltypes
+++ b/src/plugin/plugins.qmltypes
@@ -67,6 +67,12 @@ Module {
             Parameter { name: "name"; type: "string" }
         }
         Signal {
+            name: "inputActionInvoked"
+            Parameter { name: "name"; type: "string" }
+            Parameter { name: "inputText"; type: "string" }
+        }
+        
+        Signal {
             name: "closed"
             Parameter { name: "reason"; type: "uint" }
         }


### PR DESCRIPTION
- Add new replyText field in notification, set by a ReplyTextSet signal
before ActionInvoked is called.
- Optional Reply Choices hint can contain list of possible values.
- Optional Reply Editable hint allows freeform text.
- Both hints mean users may choose a template reply and edit it.
- If replyText does not conform to above, actionInvoked fails.