### PR TITLE
[nemo-qml-plugin-notification] Make it possible to configure build without QML. Fixes JB#57699

### DIFF
--- a/notifications.pro
+++ b/notifications.pro
@@ -1,7 +1,13 @@
 TEMPLATE = subdirs
 
-src_plugins.subdir = src/plugin
-src_plugins.target = sub-plugins
-src_plugins.depends = src
+SUBDIRS += src doc
 
-SUBDIRS += src src_plugins doc
+no-qml {
+    message(Building without QML dependency.)
+} else {
+    message(Building with QML dependency.)
+    src_plugins.subdir = src/plugin
+    src_plugins.target = sub-plugins
+    src_plugins.depends = src
+    SUBDIRS += src_plugins
+}


### PR DESCRIPTION
Configuring build with no-qml will drop qml dependency:

qmake CONFIG+=no-qml

In normal build qml dependency is used.

Signed-off-by: Raine Makelainen <raine.makelainen@jolla.com>