### PR TITLE
[nemo-qml-plugin-notifications] Move internal includes to cpp. Fixes JB#62143

### DIFF
--- a/src/notification.h
+++ b/src/notification.h
@@ -37,8 +37,6 @@
 
 #include <QStringList>
 #include <QDateTime>
-#include <QVariantHash>
-#include <QDBusArgument>
 
 struct NotificationData;
 


### PR DESCRIPTION
QDBusArgument in the header leaks the qdbus dependency to apps using the c++ library.

---

cc @dcaliste - happened to notice because of the related libcommhistory issue.